### PR TITLE
Fix text in getting started to properly show it in online docs

### DIFF
--- a/Pages/2.-Getting-started.md
+++ b/Pages/2.-Getting-started.md
@@ -71,14 +71,10 @@ From here you can download any missing binaries and place them in the appropriat
 
 ## Automatic syncing of module tools
 
-Multiple module tools like RECmd or EvtxECmd are included in a tool sync
-module
-[`!!ToolSync`](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/!!ToolSync.mkape).
-It runs the tools using their sync parameters. Using `--debug` switch when
-invoking KAPE, the changes are shown in the console.
+Multiple module tools like RECmd or EvtxECmd are included in a tool sync module [!!ToolSync](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/!!ToolSync.mkape).
+It runs the tools using their sync parameters. Using `--debug` switch when invoking KAPE, the changes are shown in the console.
 
-Use the sync module individually or at the start of the other modules to run
-to update the tools before using the corresponding modules.
+Use the sync module individually or at the start of the other modules to run to update the tools before using the corresponding modules.
 
 ``` powershell
 .\kape.exe --msource C:\ --mdest C:\temp\null --module !!ToolSync --debug


### PR DESCRIPTION
Sorry for the trouble. The line breaks which are removed in markdown are displayed in the online docs therefore I joined the lines.

![image](https://user-images.githubusercontent.com/30265053/107961964-cd9ffa80-6fa6-11eb-8f91-f3d1aebeedd1.png)
